### PR TITLE
Replace deprecated pyOpenSSL.crypto.load_pkcs12 with cryptography.hazma version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,18 @@ script:
       iv = $(head -c16 /dev/urandom | base64 -w0)
       signing_key = $(openssl genrsa 1024 | sed 's/^/    /')
       EOF
-  - echo '<LTD_CODEPLUG VERSION="10.05.06"/>' >test.xml
+  - |
+      cat <<EOF >test.xml
+      <LTD_CODEPLUG VERSION="10.05.06">
+        <CS_PARTITION>
+          <CS_INFO_TYPE_GRP>
+            <CS_INFO_TYPE Applicable="Enabled" ListID="0">
+              <CS_FWID Applicable="Enabled" ListID="0">0C78E1B906C54D3A8F264CE5C4F0B9DF</CS_FWID>
+            </CS_INFO_TYPE>
+          </CS_INFO_TYPE_GRP>
+        </CS_PARTITION>
+      </LTD_CODEPLUG>
+      EOF
   - python codeplug.py build test.xml
   - python codeplug.py decode test.xml.ctb
   - diff -u test.xml test.xml.ctb.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - 3.5
   - 3.6
+  - 3.7-dev
 
 install:
   - pip install .

--- a/codeplug.py
+++ b/codeplug.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.hashes import Hash, SHA1
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from OpenSSL.crypto import load_pkcs12
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
 
 
 _CP1252_BESTFIT = {
@@ -275,7 +275,7 @@ def _build_cmd(args):
     payload = etree.tostring(doc, encoding='utf-8')
 
     if 'signing_password' in config:
-        signing_key = load_pkcs12(base64.b64decode(config['signing_key']), base64.b64decode(config['signing_password'])).get_privatekey().to_cryptography_key()
+        signing_key = load_pkcs12(base64.b64decode(config['signing_key']),base64.b64decode(config['signing_password'])).key
     else:
         signing_key = load_pem_private_key(config['signing_key'].encode('ascii'), password=None, backend=backend)
 

--- a/codeplug.py
+++ b/codeplug.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.hashes import Hash, SHA1
 from cryptography.hazmat.primitives.padding import PKCS7
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from OpenSSL.crypto import load_pkcs12
+from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12
 
 
 def _int_to_bytes(number):
@@ -61,8 +61,6 @@ def decode(data, key, iv):
 
 
 def build(payload, signing_key, key, iv, backend):
-    backend = signing_key._backend
-
     signature = signing_key.sign(payload.decode('utf-8').encode('utf-16-le'), PKCS1v15(), SHA1())
 
     sign_doc = etree.Element('SIGNATURE')
@@ -132,7 +130,7 @@ def _build_cmd(args):
     payload = etree.tostring(etree.parse(args.file))
 
     if 'signing_password' in config:
-        signing_key = load_pkcs12(base64.b64decode(config['signing_key']), base64.b64decode(config['signing_password'])).get_privatekey().to_cryptography_key()
+        signing_key = load_pkcs12(base64.b64decode(config['signing_key']),base64.b64decode(config['signing_password'])).key
     else:
         signing_key = load_pem_private_key(config['signing_key'].encode('ascii'), password=None, backend=backend)
 

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ setup(
         'Topic :: Communications :: Ham Radio',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     keywords='motorola mototrbo cps ctb codeplug dmr',


### PR DESCRIPTION
Tested with sample codeplug from MOTOTRBO CPS 16.0 Build 823 AZ.
```
(env) skip@Dell-5510:~/open_src/codeplug$ python codeplug.py decode Sample_XIRM8668i.ctb
Decoded GEMSTONE archive to Sample_XIRM8668i.ctb.xml
(env) skip@Dell-5510:~/open_src/codeplug$ python codeplug.py build -o Sample_XIRM8668i_1.ctb Sample_XIRM8668i.ctb.xml
Built GEMSTONE archive in Sample_XIRM8668i_1.ctb
(env) skip@Dell-5510:~/open_src/codeplug$ python codeplug.py decode Sample_XIRM8668i_1.ctb
Decoded GEMSTONE archive to Sample_XIRM8668i_1.ctb.xml
(env) skip@Dell-5510:~/open_src/codeplug$ md5sum *.xml
ff432e71e9ff982d31cb56e8ecff8339  Sample_XIRM8668i_1.ctb.xml
ff432e71e9ff982d31cb56e8ecff8339  Sample_XIRM8668i.ctb.xml
(env) skip@Dell-5510:~/open_src/codeplug$
```

I also merged your matrix branch since it seemed to be the most recent.

Thanks for sharing this!
Amazing work.